### PR TITLE
Update find pattern to support 1.21.60

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,13 +69,13 @@ extern "C" [[gnu::visibility("default")]] void mod_init() {
         dlopen("libminecraftpe.so", 0));
 
     auto ResourcePackManager_ctor_addr = hat::find_pattern(
-        r, "55 41 57 41 56 53 48 83 EC ? 41 89 CF 49 89 D6 48 89 FB 64 48 8B 04 25 28 00 00 00 48 89 44 24 ? 48 8B 7E"_sig,
+        r, "55 41 57 41 56 41 55 41 54 53 48 83 EC ? 41 89 CF 49 89 D6 48 89 FB 64 48 8B 04 25 28 00 00 00 48 89 44 24 ? 48 8B 7E"_sig,
         hat::scan_alignment::X16);
 
     ResourcePackManager_ctor_hook = safetyhook::create_inline(ResourcePackManager_ctor_addr.get(), ResourcePackManager_ctor);
 
     auto AppPlatform_readAssetFile_addr = hat::find_pattern(
-        r, "41 57 41 56 41 54 53 48 81 EC ? ? ? ? 49 89 FE 64 48 8B 04 25 28 00 00 00 48 89 84 24 ? ? ? ? 0F 57 C0 0F 29 44 24 ? 48 8D BC 24"_sig,
+        r, "41 57 41 56 41 54 53 48 81 EC ? ? ? ? 49 89 FE 64 48 8B 04 25 28 00 00 00 48 89 84 24 ? ? ? ? 0F 57 C0 0F 29 44 24 ? 0F B6 02 A8"_sig,
         hat::scan_alignment::X16);
 
     AppPlatform_readAssetFile_hook = safetyhook::create_inline(AppPlatform_readAssetFile_addr.get(), AppPlatform_readAssetFile);


### PR DESCRIPTION
Mod does not work in 1.21.60.10 x86_64. 

I managed to update the pattern to make it work in 1.21.60.10. Obviously this change is not backwards compatible. 